### PR TITLE
Fix Weather Alerts

### DIFF
--- a/Sources/OpenWeatherKit/Internal/Extensions/APIWeather+Map.swift
+++ b/Sources/OpenWeatherKit/Internal/Extensions/APIWeather+Map.swift
@@ -15,7 +15,7 @@ extension APIWeather {
             dailyForecast: forecastDaily?.dailyForecast,
             hourlyForecast: forecastHourly?.hourForecast,
             minuteForecast: forecastNextHour?.minuteForecast,
-            weatherAlerts: weatherAlerts?.map(\.weatherAlert)
+            weatherAlerts: weatherAlerts == nil ? nil : [weatherAlerts!.weatherAlert]
         )
     }
 }

--- a/Sources/OpenWeatherKit/Internal/Extensions/APIWeather+Map.swift
+++ b/Sources/OpenWeatherKit/Internal/Extensions/APIWeather+Map.swift
@@ -15,7 +15,7 @@ extension APIWeather {
             dailyForecast: forecastDaily?.dailyForecast,
             hourlyForecast: forecastHourly?.hourForecast,
             minuteForecast: forecastNextHour?.minuteForecast,
-            weatherAlerts: weatherAlerts == nil ? nil : [weatherAlerts!.weatherAlert]
+            weatherAlerts: weatherAlerts?.weatherAlerts
         )
     }
 }

--- a/Sources/OpenWeatherKit/Internal/Extensions/APIWeatherAlerts+Map.swift
+++ b/Sources/OpenWeatherKit/Internal/Extensions/APIWeatherAlerts+Map.swift
@@ -8,12 +8,14 @@
 import Foundation
 
 extension APIWeatherAlerts {
-    var weatherAlert: WeatherAlert {
-        WeatherAlert(
-            detailsURL: detailsURL,
-            metadata: metadata.weatherMetadata,
-            alerts: alerts.map(\.alertSummary)
-        )
+    var weatherAlerts: [WeatherAlert] {
+        alerts.map {
+            WeatherAlert(
+                detailsURL: detailsURL,
+                metadata: metadata.weatherMetadata,
+                alert: $0.alertSummary
+            )
+        }
     }
 }
 

--- a/Sources/OpenWeatherKit/Internal/Extensions/WeatherQuery+QueryItems.swift
+++ b/Sources/OpenWeatherKit/Internal/Extensions/WeatherQuery+QueryItems.swift
@@ -26,7 +26,7 @@ extension Array where Element == any Query {
             case let .alerts(dataSet: _, countryCode):
                 queryItems.append(
                     URLQueryItem(
-                        name: "countryCode",
+                        name: "country",
                         value: countryCode)
                 )
             case let .daily(_, startDate, endDate):

--- a/Sources/OpenWeatherKit/Internal/Extensions/WeatherQuery+QueryItems.swift
+++ b/Sources/OpenWeatherKit/Internal/Extensions/WeatherQuery+QueryItems.swift
@@ -14,6 +14,16 @@ let isoFormatter: ISO8601DateFormatter = {
     return formatter
 }()
 
+enum QueryContants {
+    static let availability = "availability"
+    static let country = "country"
+    static let dailyEnd = "dailyEnd"
+    static let dailyStart = "dailyStart"
+    static let dataSets = "dataSets"
+    static let hourlyEnd = "hourlyEnd"
+    static let hourlyStart = "hourlyStart"
+}
+
 extension Array where Element == any Query {
     var queryItems: [URLQueryItem] {
         var queryItems: [URLQueryItem] = []
@@ -26,38 +36,44 @@ extension Array where Element == any Query {
             case let .alerts(dataSet: _, countryCode):
                 queryItems.append(
                     URLQueryItem(
-                        name: "country",
+                        name: QueryContants.country,
+                        value: countryCode)
+                )
+            case let .availability(_, countryCode):
+                queryItems.append(
+                    URLQueryItem(
+                        name: QueryContants.country,
                         value: countryCode)
                 )
             case let .daily(_, startDate, endDate):
                 queryItems.append(
                     URLQueryItem(
-                        name: "dailyStart",
+                        name: QueryContants.dailyStart,
                         value: isoFormatter.string(from: startDate))
                 )
 
                 queryItems.append(
                     URLQueryItem(
-                        name: "dailyEnd",
+                        name: QueryContants.dailyEnd,
                         value: isoFormatter.string(from: endDate))
                 )
             case let .hourly(_, startDate, endDate):
                 queryItems.append(
                     URLQueryItem(
-                        name: "hourlyStart",
+                        name: QueryContants.hourlyStart,
                         value: isoFormatter.string(from: startDate))
                 )
 
                 queryItems.append(
                     URLQueryItem(
-                        name: "hourlyEnd",
+                        name: QueryContants.hourlyEnd,
                         value: isoFormatter.string(from: endDate))
                 )
             default: break
             }
         }
 
-        queryItems.append(URLQueryItem(name: "dataSets", value: dataSets.joined(separator: ",")))
+        queryItems.append(URLQueryItem(name: QueryContants.dataSets, value: dataSets.joined(separator: ",")))
 
         return queryItems
     }

--- a/Sources/OpenWeatherKit/Internal/Models/APIWeather.swift
+++ b/Sources/OpenWeatherKit/Internal/Models/APIWeather.swift
@@ -13,7 +13,7 @@ struct APIWeather: Codable, Equatable {
     let forecastDaily: APIForecastDaily?
     let forecastHourly: APIForecastHourly?
     let forecastNextHour: APIForecastNextHour?
-    let weatherAlerts: [APIWeatherAlerts]?
+    let weatherAlerts: APIWeatherAlerts?
 
     enum CodingKeys: String, CodingKey {
         case currentWeather = "currentWeather"

--- a/Sources/OpenWeatherKit/Internal/NetworkClient.swift
+++ b/Sources/OpenWeatherKit/Internal/NetworkClient.swift
@@ -25,9 +25,14 @@ struct NetworkClient {
 
     func fetchAvailability(
         location: Location,
+        countryCode: String,
         jwt: String
     ) async throws -> [APIWeatherAvailability] {
-        try await get(.availability(location), jwt: jwt)
+        try await get(
+            .availability(location),
+            queryItems: [URLQueryItem(name: QueryContants.country, value: countryCode)],
+            jwt: jwt
+        )
     }
 
     func fetchWeather(
@@ -40,8 +45,15 @@ struct NetworkClient {
             var _queries = queries
 
             if let index = _queries.firstIndex(where: { $0 is WeatherQuery<WeatherAvailability> }) {
+                guard case let .availability(_, countryCode) = _queries[index].queryType else {
+                    preconditionFailure("Invalid QueryType on WeatherQuery<WeatherAvailability>")
+                }
+
                 group.addTask {
-                    let availability: [APIWeatherAvailability] = try await fetchAvailability(location: location, jwt: jwt)
+                    let availability: [APIWeatherAvailability] = try await fetchAvailability(
+                        location: location,
+                        countryCode: countryCode,
+                        jwt: jwt)
                     return availability.weatherProxy
                 }
 

--- a/Sources/OpenWeatherKit/Internal/Query.swift
+++ b/Sources/OpenWeatherKit/Internal/Query.swift
@@ -19,7 +19,7 @@ enum QueryType {
     case daily(_ dataSet: String, _ startDate: Date, _ endDate: Date)
     case hourly(_ dataSet: String, _ startDate: Date, _ endDate: Date)
     case minute(_ dataSet: String)
-    case availability(_ dataSet: String)
+    case availability(_ dataSet: String, _ countryCode: String)
 
     var dataSet: String {
         switch self {
@@ -28,7 +28,7 @@ enum QueryType {
         case let .daily(dataSet, _, _): return dataSet
         case let .hourly(dataSet, _, _): return dataSet
         case let .minute(dataSet): return dataSet
-        case let .availability(dataSet): return dataSet
+        case let .availability(dataSet, _): return dataSet
         }
     }
 }

--- a/Sources/OpenWeatherKit/Public/Forecast/WeatherAlert.swift
+++ b/Sources/OpenWeatherKit/Public/Forecast/WeatherAlert.swift
@@ -6,9 +6,9 @@
 //
 
 import Foundation
+import WeatherKit
 
 public struct WeatherAlert: Sendable {
-
     /// The site for more details about the weather alert. Required link for attribution.
     public var detailsURL: URL
 
@@ -16,7 +16,7 @@ public struct WeatherAlert: Sendable {
     public var metadata: WeatherMetadata
 
     /// Detailed information about the weather alert.
-    public var alerts: [AlertSummary]
+    public var alert: AlertSummary
 }
 
 extension WeatherAlert: Codable {}

--- a/Sources/OpenWeatherKit/Public/Forecast/WeatherAlert.swift
+++ b/Sources/OpenWeatherKit/Public/Forecast/WeatherAlert.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import WeatherKit
 
 public struct WeatherAlert: Sendable {
     /// The site for more details about the weather alert. Required link for attribution.

--- a/Sources/OpenWeatherKit/Public/Requests/WeatherQuery.swift
+++ b/Sources/OpenWeatherKit/Public/Requests/WeatherQuery.swift
@@ -7,10 +7,6 @@
 
 import Foundation
 
-enum QueryContants {
-    static let availability = "availability"
-}
-
 public struct WeatherQuery<T> {
     let queryType: QueryType
     let weatherKeyPath: KeyPath<WeatherProxy, T?>
@@ -53,13 +49,6 @@ public struct WeatherQuery<T> {
             ),
             weatherKeyPath: \.dailyForecast
         )
-    }
-
-    /// The availability query.
-    public static var availability: WeatherQuery<WeatherAvailability> {
-        WeatherQuery<WeatherAvailability>(
-            queryType: .availability(QueryContants.availability),
-            weatherKeyPath: \.availability)
     }
 }
 
@@ -106,5 +95,17 @@ public extension WeatherQuery where T == [WeatherAlert]? {
             ),
             weatherKeyPath: \.weatherAlerts?
         )
+    }
+}
+
+public extension WeatherQuery where T == WeatherAvailability {
+    /// The availability query.
+    static func availability(countryCode: String) -> WeatherQuery<WeatherAvailability> {
+        WeatherQuery<WeatherAvailability>(
+            queryType: .availability(
+                QueryContants.availability,
+                countryCode
+            ),
+            weatherKeyPath: \.availability)
     }
 }

--- a/Sources/OpenWeatherKit/Public/WeatherService.swift
+++ b/Sources/OpenWeatherKit/Public/WeatherService.swift
@@ -115,7 +115,7 @@ final public class WeatherService: Sendable {
                 WeatherQuery<Forecast<HourWeather>>.hourly,
                 WeatherQuery<Forecast<DayWeather>>.daily,
                 WeatherQuery<[WeatherAlert]?>.alerts(countryCode: countryCode),
-                WeatherQuery<WeatherAvailability>.availability,
+                WeatherQuery<WeatherAvailability>.availability(countryCode: countryCode),
             jwt: Self.configuration.jwt()
         )
 


### PR DESCRIPTION
The URL query param should be "country" instead of "countryCode". Also the availability endpoint needs "country".

Restructured the `WeatherAlert` type. This type does not match up to `WeatherKit`'s implementation, but I think it is better. The REST API communicates more information about the alert so I've included this information ++.

---

- update country code param
- alerts are an array
- refactor WeatherAlert type structure and county query param
