### PR TITLE
Update APIForecastDaily.swift

### DIFF
--- a/Sources/OpenWeatherKit/Internal/Models/APIForecastDaily.swift
+++ b/Sources/OpenWeatherKit/Internal/Models/APIForecastDaily.swift
@@ -28,7 +28,7 @@ struct APIDay: Codable, Equatable {
     let maxUvIndex: Int
     let moonPhase: String
     let moonrise: Date?
-    let moonset: Date
+    let moonset: Date?
     let precipitationAmount: Double
     let precipitationChance: Double
     let precipitationType: String


### PR DESCRIPTION
Solves JSON decoding error (`moonset` is an optional)
```
"No value associated with key CodingKeys(stringValue: \"moonset\", intValue: nil) (\"moonset\")."	
```